### PR TITLE
Fix ego pose

### DIFF
--- a/team_code/uniad_b2d_agent.py
+++ b/team_code/uniad_b2d_agent.py
@@ -174,7 +174,7 @@ class UniadAgent(autonomous_agent.AutonomousAgent):
             EARTH_RADIUS_EQUA = 6378137.0
             def equations(vars):
                 x, y = vars
-                eq1 = lon * math.cos(x * math.pi / 180) - (locx * x * 180) / (math.pi * EARTH_RADIUS_EQUA) - math.cos(x * math.pi / 180) * y
+                eq1 = lon * math.cos(x * math.pi / 180) - (locx * 180) / (math.pi * EARTH_RADIUS_EQUA) - math.cos(x * math.pi / 180) * y
                 eq2 = math.log(math.tan((lat + 90) * math.pi / 360)) * EARTH_RADIUS_EQUA * math.cos(x * math.pi / 180) + locy - math.cos(x * math.pi / 180) * EARTH_RADIUS_EQUA * math.log(math.tan((90 + x) * math.pi / 360))
                 return [eq1, eq2]
             initial_guess = [0, 0]

--- a/team_code/vad_b2d_agent.py
+++ b/team_code/vad_b2d_agent.py
@@ -177,7 +177,7 @@ class VadAgent(autonomous_agent.AutonomousAgent):
             EARTH_RADIUS_EQUA = 6378137.0
             def equations(vars):
                 x, y = vars
-                eq1 = lon * math.cos(x * math.pi / 180) - (locx * x * 180) / (math.pi * EARTH_RADIUS_EQUA) - math.cos(x * math.pi / 180) * y
+                eq1 = lon * math.cos(x * math.pi / 180) - (locx * 180) / (math.pi * EARTH_RADIUS_EQUA) - math.cos(x * math.pi / 180) * y
                 eq2 = math.log(math.tan((lat + 90) * math.pi / 360)) * EARTH_RADIUS_EQUA * math.cos(x * math.pi / 180) + locy - math.cos(x * math.pi / 180) * EARTH_RADIUS_EQUA * math.log(math.tan((90 + x) * math.pi / 360))
                 return [eq1, eq2]
             initial_guess = [0, 0]

--- a/team_code/vad_b2d_agent_visualize.py
+++ b/team_code/vad_b2d_agent_visualize.py
@@ -205,7 +205,7 @@ class VadAgent(autonomous_agent.AutonomousAgent):
             EARTH_RADIUS_EQUA = 6378137.0
             def equations(vars):
                 x, y = vars
-                eq1 = lon * math.cos(x * math.pi / 180) - (locx * x * 180) / (math.pi * EARTH_RADIUS_EQUA) - math.cos(x * math.pi / 180) * y
+                eq1 = lon * math.cos(x * math.pi / 180) - (locx * 180) / (math.pi * EARTH_RADIUS_EQUA) - math.cos(x * math.pi / 180) * y
                 eq2 = math.log(math.tan((lat + 90) * math.pi / 360)) * EARTH_RADIUS_EQUA * math.cos(x * math.pi / 180) + locy - math.cos(x * math.pi / 180) * EARTH_RADIUS_EQUA * math.log(math.tan((90 + x) * math.pi / 360))
                 return [eq1, eq2]
             initial_guess = [0, 0]


### PR DESCRIPTION
As pointed out by @ChipsICU in [Bench2Drive/issues/62](https://github.com/Thinklab-SJTU/Bench2Drive/issues/62):

> the calculation of lat_ref and lon_ref seems to be wrong

There is actually a mistake in the formula: an extra multiplication by `x` in the numerator. This leads to a wrong absolute ego pose. Now, I fixed the formula in all three agent files.