### PR TITLE
Fix get_root_logger call to use keyword arg for log_level

### DIFF
--- a/adzoo/bevformer/apis/mmdet_train.py
+++ b/adzoo/bevformer/apis/mmdet_train.py
@@ -30,7 +30,7 @@ def custom_train_detector(model,
                    timestamp=None,
                    eval_model=None,
                    meta=None):
-    logger = get_root_logger(cfg.log_level)
+    logger = get_root_logger(log_level=cfg.log_level)
 
     # prepare data loaders
    

--- a/adzoo/bevformer/mmdet3d_plugin/bevformer/apis/mmdet_train.py
+++ b/adzoo/bevformer/mmdet3d_plugin/bevformer/apis/mmdet_train.py
@@ -35,7 +35,7 @@ def custom_train_detector(model,
                    timestamp=None,
                    eval_model=None,
                    meta=None):
-    logger = get_root_logger(cfg.log_level)
+    logger = get_root_logger(log_level=cfg.log_level)
 
     # prepare data loaders
    

--- a/adzoo/vad/apis/mmdet_train.py
+++ b/adzoo/vad/apis/mmdet_train.py
@@ -29,7 +29,7 @@ def custom_train_detector(model,
                    timestamp=None,
                    eval_model=None,
                    meta=None):
-    logger = get_root_logger(cfg.log_level)
+    logger = get_root_logger(log_level=cfg.log_level)
 
     # prepare data loaders
    


### PR DESCRIPTION
### What / Why

As mentioned in https://github.com/Thinklab-SJTU/Bench2DriveZoo/issues/108, `get_root_logger(cfg.log_level)` passes `cfg.log_level` as a positional argument, which is interpreted as `log_file` according to the function signature.
This results in incorrect logger configuration and causes unexpected behavior

### Reproduce

[Train BEVFormer](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/docs/TRAIN_EVAL.md#train)

```bash
./adzoo/bevformer/dist_train.sh ./adzoo/bevformer/configs/bevformer/bevformer_base_b2d.py 4
```

As a result, an unexpected folder `INFO` is created because of the unmatched argument above.

### Fix

Change `get_root_logger(cfg.log_level)` to `get_root_logger(log_level=cfg.log_level)`

### Verification

Confirmed that the script (`./adzoo/bevformer/dist_train.sh ./adzoo/bevformer/configs/bevformer/bevformer_base_b2d.py 4`) returned the same result and `INFO` folder was not created.