### PR TITLE
Pin Pillow version to avoid 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cython
 numba==0.48.0 # In order to speed up
 addict
 packaging
-Pillow
+Pillow==9.5.0
 matplotlib
 regex;sys_platform=='win32'
 pycocotools; platform_system == "Linux"


### PR DESCRIPTION
### What / Why

As mentioned in https://github.com/Thinklab-SJTU/Bench2DriveZoo/issues/110, latest Pillow (>=10) causes a compatibility error with `numpy==1.20.0` that is installed based on [requirements.txt](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/requirements.txt)

### Reproduce

[Prepare Bench2Drive data info](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/docs/DATA_PREP.md#prepare-bench2drive-data-info)

```bash
python prepare_B2D.py --workers 16
```

The following error occurred

```console
AttributeError: module 'numpy.typing' has no attribute 'NDArray'
```

### Fix

Pin the Pillow version (9.5.0) of [requirements.txt](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/requirements.txt)

### Verification

Confirmed that the specified Pillow is installed and the AttributeError doesn't occur