### PR TITLE
Enable `FORCE_CUDA` environment variable in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,10 @@ from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtensio
 EXT_TYPE = 'pytorch'
 cmd_class = {'build_ext': BuildExtension}
 
+def check_cuda_availability():
+    force_cuda = os.getenv('FORCE_CUDA', '0') == '1'
+    return torch.cuda.is_available() or force_cuda
+
 def make_cuda_ext(name,
                   module,
                   sources,
@@ -20,7 +24,7 @@ def make_cuda_ext(name,
     define_macros = []
     extra_compile_args = {'cxx': [] + extra_args}
 
-    if torch.cuda.is_available():
+    if check_cuda_availability():
         define_macros += [('WITH_CUDA', None)]
         extension = CUDAExtension
         extra_compile_args['nvcc'] = extra_args + [
@@ -144,7 +148,7 @@ def get_extensions():
 
         include_dirs = []
 
-        if torch.cuda.is_available():
+        if check_cuda_availability():
             define_macros += [('MMCV_WITH_CUDA', None)]
             cuda_args = os.getenv('MMCV_CUDA_ARGS')
             extra_compile_args['nvcc'] = [cuda_args] if cuda_args else []


### PR DESCRIPTION
### What / Why

As mentioned in https://github.com/Thinklab-SJTU/Bench2DriveZoo/issues/111, the current [setup.py](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/setup.py) ignores an environment variable `FORCE_CUDA` which is used for enabling GPU-based build without GPU visible environment.

### Reproduce

[Install the repo](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/docs/INSTALL.md) in non-GPU environment such as Docker build

```bash
pip install -v -e .
```

Then run [BEVFormer eval script](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/docs/TRAIN_EVAL.md#open-loop-eval)

```bash
./adzoo/bevformer/dist_test.sh ./adzoo/bevformer/configs/bevformer/bevformer_base_b2d.py ./ckpts/bevformer_base_b2d.pth 1
```

The following error occurred

```console
ImportError: /workspace/Bench2DriveZoo/mmcv/ops/roiaware_pool3d/roiaware_pool3d_ext.cpython-38-x86_64-linux-gnu.so: undefined symbol: _Z19points_in_boxes_gpuN2at6TensorES0_S0_
E0205 05:58:29.819793 136488267859136 torch/distributed/elastic/multiprocessing/api.py:833] failed
```

### Fix

Enable `FORCE_CUDA` environment variable in setup.py

### Verification

Confirmed that the GPU-build is available both in GPU environments and non-GPU environments such as Docker containers.