### PR TITLE
Fix TRAIN_EVAL.md for UniAD Base Open loop eval

### DIFF
--- a/docs/TRAIN_EVAL.md
+++ b/docs/TRAIN_EVAL.md
@@ -45,7 +45,7 @@ You can use following commands to train and validate [BEVFormer](https://github.
 
 ```bash
 #eval UniAD base
-./adzoo/uniad/uniad_dist_eval.sh ./adzoo/uniad/configs/stage2_e2e/base_e2e_b2d.py 1
+./adzoo/uniad/uniad_dist_eval.sh ./adzoo/uniad/configs/stage2_e2e/base_e2e_b2d.py ./ckpts/uniad_base_b2d.pth 1
 #eval UniAD tiny
 ./adzoo/uniad/uniad_dist_eval.sh ./adzoo/uniad/configs/stage2_e2e/tiny_e2e_b2d.py ./ckpts/uniad_tiny_b2d.pth 1
 ```


### PR DESCRIPTION
### What / Why

As mentioned in https://github.com/Thinklab-SJTU/Bench2DriveZoo/issues/112, The current UniAD Base Open loop eval command raises an error.

### Reproduce

[UniAD Base Open loop eval](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/docs/TRAIN_EVAL.md#open-loop-eval-1)

```bash
./adzoo/uniad/uniad_dist_eval.sh ./adzoo/uniad/configs/stage2_e2e/base_e2e_b2d.py 1
```

The following error occurred 

```console
Traceback (most recent call last):
  File "/opt/conda/envs/b2d_zoo/lib/python3.8/site-packages/torch/distributed/run.py", line 632, in determine_local_world_size
    return int(nproc_per_node)
ValueError: invalid literal for int() with base 10: ''
```

### Fix

Change [UniAD Base Open loop eval document](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/docs/TRAIN_EVAL.md#open-loop-eval-1) as follows

```
./adzoo/uniad/uniad_dist_eval.sh ./adzoo/uniad/configs/stage2_e2e/base_e2e_b2d.py ./ckpts/uniad_base_b2d.pth 1
```

### Verification

Confirmed that the new Open loop eval command successfully returns the results