### PR TITLE
Fix reshape process of OccHead class

### DIFF
--- a/mmcv/models/dense_heads/occ_head.py
+++ b/mmcv/models/dense_heads/occ_head.py
@@ -426,8 +426,8 @@ class OccHead(BaseModule):
             out_dict['ins_seg_gt'] = self.get_ins_seg_gt(gt_instance[:, :1+self.n_future])  # [1, 5, 200, 200]
         if no_query:
             # output all zero results
-            out_dict['seg_out'] = torch.zeros((1, 5, 1, 200, 200),device=bev_feat.device).long()  # [1, 5, 1, 200, 200]
-            out_dict['ins_seg_out'] = torch.zeros((1, 5, 1, 200, 200),device=bev_feat.device).long()  # [1, 5, 200, 200]
+            out_dict['seg_out'] = torch.zeros_like(out_dict['seg_gt']).long()  # [1, 5, 1, 200, 200]
+            out_dict['ins_seg_out'] = torch.zeros_like(out_dict['ins_seg_gt']).long()  # [1, 5, 200, 200]
             return out_dict
 
 

--- a/mmcv/models/dense_heads/occ_head.py
+++ b/mmcv/models/dense_heads/occ_head.py
@@ -426,8 +426,15 @@ class OccHead(BaseModule):
             out_dict['ins_seg_gt'] = self.get_ins_seg_gt(gt_instance[:, :1+self.n_future])  # [1, 5, 200, 200]
         if no_query:
             # output all zero results
-            out_dict['seg_out'] = torch.zeros_like(out_dict['seg_gt']).long()  # [1, 5, 1, 200, 200]
-            out_dict['ins_seg_out'] = torch.zeros_like(out_dict['ins_seg_gt']).long()  # [1, 5, 200, 200]
+            if 'seg_gt' in out_dict:
+                out_dict['seg_out'] = torch.zeros_like(out_dict['seg_gt']).long()  # [1, 5, 1, 200, 200]
+                out_dict['ins_seg_out'] = torch.zeros_like(out_dict['ins_seg_gt']).long()  # [1, 5, 200, 200]
+            else:
+                # No GT available (e.g. closed-loop evaluation): create zero tensors from known dimensions
+                t = 1 + self.n_future  # number of time steps
+                h, w = self.bev_size
+                out_dict['seg_out'] = torch.zeros((1, t, 1, h, w), dtype=torch.long, device=bev_feat.device)
+                out_dict['ins_seg_out'] = torch.zeros((1, t, h, w), dtype=torch.long, device=bev_feat.device)
             return out_dict
 
 


### PR DESCRIPTION
### What / Why

As mentioned in https://github.com/Thinklab-SJTU/Bench2DriveZoo/pull/117, The current [OccHead reshape process](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/mmcv/models/dense_heads/occ_head.py#L429) doesn't match its comment as follows

```
if no_query:
    # output all zero results
    out_dict['seg_out'] = torch.zeros((1, 5, 1, 200, 200),device=bev_feat.device).long()  # [1, 5, 1, 200, 200]
    out_dict['ins_seg_out'] = torch.zeros((1, 5, 1, 200, 200),device=bev_feat.device).long()  # [1, 5, 200, 200]
    return out_dict
```

Furthermore, it causes an error when running UniAD 

### Reproduce

[UniAD Base Open loop eval](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/docs/TRAIN_EVAL.md#open-loop-eval-1)

```bash
./adzoo/uniad/uniad_dist_eval.sh ./adzoo/uniad/configs/stage2_e2e/base_e2e_b2d.py ./ckpts/uniad_base_b2d.pth 1
```

The following error occurred when reaching iteration number 221

```console
[                           ] 221/12806, 0.3 task/s, elapsed: 741s, ETA: 42196sTraceback (most recent call last):
  File "./adzoo/uniad/test.py", line 145, in <module>
    main()
  File "./adzoo/uniad/test.py", line 124, in main
    outputs = custom_multi_gpu_test(model, data_loader, args.tmpdir, args.gpu_collect)
  File "/workspace/Bench2DriveZoo/adzoo/uniad/test_utils.py", line 115, in custom_multi_gpu_test
    panoptic_metrics[key](result[0]['occ']['ins_seg_out'][..., limits, limits].contiguous().detach(),
  File "/opt/conda/envs/b2d_zoo/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/opt/conda/envs/b2d_zoo/lib/python3.8/site-packages/torchmetrics/metric.py", line 234, in forward
    self._forward_cache = self._forward_full_state_update(*args, **kwargs)
  File "/opt/conda/envs/b2d_zoo/lib/python3.8/site-packages/torchmetrics/metric.py", line 247, in _forward_full_state_update
    self.update(*args, **kwargs)
  File "/opt/conda/envs/b2d_zoo/lib/python3.8/site-packages/torchmetrics/metric.py", line 390, in wrapped_func
    update(*args, **kwargs)
  File "/workspace/Bench2DriveZoo/mmcv/models/dense_heads/occ_head_plugin/metrics.py", line 111, in update
    result = self.panoptic_metrics(
  File "/workspace/Bench2DriveZoo/mmcv/models/dense_heads/occ_head_plugin/metrics.py", line 156, in panoptic_metrics
    assert pred_segmentation.dim() == 2
AssertionError
ERROR:torch.distributed.elastic.multiprocessing.api:failed (exitcode: 1) local_rank: 0 (pid: 128) of binary: /opt/conda/envs/b2d_zoo/bin/python
```

### Fix

Based on [the latest UniAD repo](https://github.com/OpenDriveLab/UniAD/blob/v2.0/projects/mmdet3d_plugin/uniad/dense_heads/occ_head.py#L425), change [the reshaping process](https://github.com/Thinklab-SJTU/Bench2DriveZoo/blob/uniad/vad/mmcv/models/dense_heads/occ_head.py#L429)  as follows

```
if no_query:
    # output all zero results
    out_dict['seg_out'] = torch.zeros_like(out_dict['seg_gt']).long()  # [1, 5, 1, 200, 200]
    out_dict['ins_seg_out'] = torch.zeros_like(out_dict['ins_seg_gt']).long()  # [1, 5, 200, 200]
    return out_dict
```

### Verification

Confirmed that the new Open loop eval command successfully returns the results